### PR TITLE
.format non funziona senza variabile

### DIFF
--- a/lezione3/2_string_manipulation.py
+++ b/lezione3/2_string_manipulation.py
@@ -93,11 +93,13 @@ print(x)
 # È possibile formattare stringhe usando il metodo .format
 
 msg1 = 'Fred scored {} out of {} points.'
-msg1.format(3, 10)
+x = msg1.format(3, 10)
+print(x)
 # => 'Fred scored 3 out of 10 points.'
  
 msg2 = 'Fred {verb} a {adjective} {noun}.'
-msg2.format(adjective='fluffy', verb='tickled', noun='hamster')
+x = msg2.format(adjective='fluffy', verb='tickled', noun='hamster')
+print(x)
 # => 'Fred tickled a fluffy hamster.'
 
 # In realtà è addirittura possibile usare la funzione print per farlo direttamente in fase di stampa


### PR DESCRIPTION
Quando si usa il .format è necessario specificarlo come all'interno di una variabile, e poi stampare la variabile in questione per formattarlo in maniera corretta. Senza, facendo ad esempio:

txt = ("Ciao {utente}, benvenuto su ...")
txt.format(utente="Pierino")
print(**txt**)

quello che stamperà sarà "Ciao {utente}, benvenuto su ..." in quanto il programma stampa direttamente la variabile txt ignorando il .format

se invece scriviamo:

txt = ("Ciao {utente}, benvenuto su ...")
**variabile** = txt.format(utente="Pierino")
print(**variabile**)

otterremo "Ciao Perino, benvenuto su ..."