### PR TITLE
Nome lista errato nel codice di Compito 02

### DIFF
--- a/lezione6/compiti/compiti.md
+++ b/lezione6/compiti/compiti.md
@@ -26,7 +26,7 @@ def doubler(l):
 		l[i] = l[i]*2
 	
 l1 = [1,2,3]
-doubler(l)
+doubler(l1)
 
 ```
 


### PR DESCRIPTION
Il nome della lista che viene passata alla funzione doubler in Compito 02 non corrisponde a quello della lista inizializzata alla riga precedente.